### PR TITLE
upgrade spark version from 2.4.1 to 2.4.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSI
     && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
 COPY docker/apache-download.sh /apache-download.sh
-ENV SPARK_VERSION 2.4.1
+ENV SPARK_VERSION 2.4.3
 ENV HADOOP_VERSION 2.7
 RUN cd /usr/local && \
     /apache-download.sh spark/spark-$SPARK_VERSION/spark-$SPARK_VERSION-bin-hadoop$HADOOP_VERSION.tgz && \


### PR DESCRIPTION
Perhaps, Spark tar files are frequently uploaded and the old ones are deleted here: http://apachemirror.wuchna.com/spark/ 

http://apachemirror.wuchna.com/spark/spark-2.4.1/spark-2.4.1-bin-hadoop2.7.tgz returns 404 not found.
