### PR TITLE
Use a single writer script for recommendations and stats writer

### DIFF
--- a/listenbrainz_spark/rabbitmq_writer/rabbitmq_writer.py
+++ b/listenbrainz_spark/rabbitmq_writer/rabbitmq_writer.py
@@ -5,7 +5,7 @@ import time
 import json
 import sys
 
-class StatsWriter():
+class RabbitmqWriter():
     def __init__(self):
         self.unique_ch = None
         self.ERROR_RETRY_DELAY = 3

--- a/listenbrainz_spark/stats/user.py
+++ b/listenbrainz_spark/stats/user.py
@@ -256,7 +256,7 @@ def main():
             user_name : metadata,
         }
         try:
-            rabbbitmq_conn_obj.start(rabbitmq_data)
+            rabbbitmq_conn_obj.start(rabbitmq_data, config.SPARK_EXCHANGE, config.SPARK_QUEUE)
             logging.info("Statistics of %s pushed to rabbitmq" % (user_name))
         except pika.exceptions.ConnectionClosed:
             logging.error("Connection to rabbitmq closed while trying to publish: Statistics of %s not published" % (user_name))

--- a/listenbrainz_spark/stats/user.py
+++ b/listenbrainz_spark/stats/user.py
@@ -6,7 +6,7 @@ import logging
 import pika
 
 from collections import defaultdict
-from listenbrainz_spark.stats_writer.stats_writer import StatsWriter
+from listenbrainz_spark.rabbitmq_writer.rabbitmq_writer import RabbitmqWriter
 from listenbrainz_spark import config
 from listenbrainz_spark.stats import run_query
 from listenbrainz_spark.stats import date_for_stats_calculation
@@ -212,7 +212,7 @@ def main():
     #   'user1' : {
     #       'artist' : {artists dict returned by func get_artists},
     #       'recordings' : {recordings dict returned by func get_recordings},
-    #       'releases': {releases dict returned by func get_releasess},
+    #       'releases': {releases dict returned by func get_releases},
     #       'yearmonth' : 'date when the stats were calculated'
     #   },
     #   'user2' : {...}
@@ -247,7 +247,7 @@ def main():
     for user_name, release_stats in release_data.items():
         data[user_name]['releases'] = release_stats
 
-    rabbbitmq_conn_obj = StatsWriter()
+    rabbbitmq_conn_obj = RabbitmqWriter()
     yearmonth = datetime.strftime(date, '%Y-%m')
     for user_name, metadata in data.items():
         data[user_name]['yearmonth'] = yearmonth


### PR DESCRIPTION
A single *writer* script can be used to write stats and recommendations to different queues and exchanges. 
We can think of renaming stats_writer.py for it can write any type of data(stats, recommendations, etc) to the given queue. 