### PR TITLE
Config values and spark submit params for standalone mode

### DIFF
--- a/config.sh.sample
+++ b/config.sh.sample
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 SPARK_URI="spark://spark-master.spark-network:7077"
-EXECUTOR_COUNT=7
+LISTENERBUS_CAPACITY="100000"
+MAX_CORES="20"
+EXECUTOR_CORES="5"
 EXECUTOR_MEMORY="3g"
 DRIVER_MEMORY="6g"
-
 CONTAINER_NAME="listenbrainz-jobs-`whoami`"

--- a/spark-submit.sh
+++ b/spark-submit.sh
@@ -6,8 +6,10 @@ zip -r listenbrainz_spark.zip listenbrainz_spark/
 time ./run.sh /usr/local/spark/bin/spark-submit \
 	--packages org.apache.spark:spark-avro_2.11:2.4.1 \
 	--master $SPARK_URI \
-	--num-executors=$EXECUTOR_COUNT \
-	--executor-memory=$EXECUTOR_MEMORY \
-	--driver-memory=$DRIVER_MEMORY \
+	--conf "spark.scheduler.listenerbus.eventqueue.capacity"=$LISTENERBUS_CAPACITY \
+    --conf "spark.cores.max"=$MAX_CORES \
+    --conf "spark.executor.cores"=$EXECUTOR_CORES \
+    --conf "spark.executor.memory"=$EXECUTOR_MEMORY \
+    --conf "spark.driver.memory"=$DRIVER_MEMORY \
 	--py-files listenbrainz_spark.zip \
 	"$@"

--- a/spark-submit.sh
+++ b/spark-submit.sh
@@ -7,9 +7,9 @@ time ./run.sh /usr/local/spark/bin/spark-submit \
 	--packages org.apache.spark:spark-avro_2.11:2.4.1 \
 	--master $SPARK_URI \
 	--conf "spark.scheduler.listenerbus.eventqueue.capacity"=$LISTENERBUS_CAPACITY \
-    --conf "spark.cores.max"=$MAX_CORES \
-    --conf "spark.executor.cores"=$EXECUTOR_CORES \
-    --conf "spark.executor.memory"=$EXECUTOR_MEMORY \
-    --conf "spark.driver.memory"=$DRIVER_MEMORY \
+    	--conf "spark.cores.max"=$MAX_CORES \
+    	--conf "spark.executor.cores"=$EXECUTOR_CORES \
+    	--conf "spark.executor.memory"=$EXECUTOR_MEMORY \
+    	--conf "spark.driver.memory"=$DRIVER_MEMORY \
 	--py-files listenbrainz_spark.zip \
 	"$@"


### PR DESCRIPTION
The variables (--num-executors, etc) are used with YARN as a resource manager. With standalone mode 
*--conf* should be used. 
Config values are the ones which I find suitable for data of size varying from MBs to few GBs. Can be changed as and when data size changes, other parameters (spark.shuffle.partitions, etc) can also be added.