### PR TITLE
Modify develop.sh to use a single command for building services and starting containers

### DIFF
--- a/develop.sh
+++ b/develop.sh
@@ -5,4 +5,4 @@ if [[ ! -d "docker" ]]; then
     exit -1
 fi
 
-docker-compose -f docker/docker-compose.dev.yml -p listenbrainzspark "$@"
+docker-compose -f docker/docker-compose.dev.yml -p listenbrainzspark build && docker-compose -f docker/docker-compose.dev.yml -p listenbrainzspark up


### PR DESCRIPTION
Presently, we need to issue two commands: 
- develop.sh down to stop the running containers
- develop.sh up to start the containers

With this PR only one command ( develop.sh ) would be enough to build and start all the services. 