### PR TITLE
Remove zip created on every run of spark-submit

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -106,6 +106,11 @@ def user():
     from listenbrainz_spark.stats import user
     user.main()
 
+@cli.resultcallback()
+def remove_zip(result, **kwargs):
+    """ Remove zip created by spark-submit.
+    """
+    os.remove(os.path.join('/', 'rec', 'listenbrainz_spark.zip'))
 
 if __name__ == '__main__':
     # The root logger always defaults to WARNING level


### PR DESCRIPTION
spark-submit's --py-file param takes python files in .zip, .egg etc format. We are using .zip format to create a zip of listenbrainz_spark folder. On every run, spark-submit creates a new zip (to include modifications) and save it in the location from where spark-submit has been called. 
After a script has been executed, this zip file is of no use and hence should be deleted.