### PR TITLE
Add a new docker image to set up cron for statistics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,3 +49,14 @@ COPY . /rec
 
 FROM metabrainz-spark-base as metabrainz-spark-dev
 COPY . /rec
+
+FROM metabrainz-spark-base as metabrainz-spark-cron
+
+RUN apt-get -y install cron
+COPY admin/stats-crontab /tmp/stats-crontab
+# TODO: don't do this with root, add a new user
+RUN cat /tmp/stats-crontab >> /etc/crontabs/root
+RUN rm /tmp/stats-crontab
+RUN touch /var/log/cron.log
+COPY . /rec
+CMD crond 2>&1 > /dev/null && tail -f /var/log/cron.log

--- a/admin/stats-crontab
+++ b/admin/stats-crontab
@@ -1,0 +1,1 @@
+00 00 * * 2,5 /rec/spark-submit.sh manage.py user


### PR DESCRIPTION
The container would be running cron jobs from the cluster. this seems like an okay plan for now while we're still on the hetzner vms and if we go to permanent hetzner machines, it should be good too. 

## Open questions

* How do we handle private configs in the vms? the vms do not have consul. 
* Is it possible right now to connect to the rabbitmq instance on our main machines from the VMs? If so, what's the IP address / host and port?