### PR TITLE
Update model_metadata partially with create_dataframes

### DIFF
--- a/listenbrainz_spark/config.py.sample
+++ b/listenbrainz_spark/config.py.sample
@@ -43,3 +43,8 @@ LOG_SENTRY = {
     'environment': 'development',
     'level': 'ERROR',
 }
+
+# Model id is made up of two parts.
+# String + UUID
+# The following var defines the string of which the model id is made up of.
+MODEL_ID_PREFIX = 'listenbrainz-recommendation-model'

--- a/listenbrainz_spark/exceptions.py
+++ b/listenbrainz_spark/exceptions.py
@@ -5,6 +5,21 @@ class SparkException(Exception):
     def __str__(self):
         return self.message
 
+class DataFrameNotAppendedException(SparkException):
+    """ Failed to append a dataframe to existing dataframe in HDFS or
+        failed to write a new dataframe to HDFS.
+    """
+    def __init__(self, message, schema):
+        self.error_msg = 'DataFrame with following schema not appended: \n{}\n{}'.format(schema, message)
+        super(DataFrameNotAppendedException, self).__init__(self.error_msg)
+
+class DataFrameNotCreatedException(SparkException):
+    """ Failed to create a new dataframe.
+    """
+    def __init__(self, message, row):
+        self.error_msg = 'Cannot create dataframe for following row object: \n{}\n{}'.format(row, message)
+        super(DataFrameNotCreatedException, self).__init__(self.error_msg)
+
 class FileNotFetchedException(SparkException):
     """ Failed to fetch a file from secondary storage.
     """

--- a/listenbrainz_spark/utils.py
+++ b/listenbrainz_spark/utils.py
@@ -6,15 +6,28 @@ import traceback
 from py4j.protocol import Py4JJavaError
 
 import listenbrainz_spark
-from listenbrainz_spark import stats
-from listenbrainz_spark import config
+from listenbrainz_spark import stats, config, schema
 from listenbrainz_spark.stats import run_query
 from listenbrainz_spark import hdfs_connection
 
-from listenbrainz_spark.exceptions import FileNotSavedException, ViewNotRegisteredException, PathNotFoundException, FileNotFetchedException
+from listenbrainz_spark.exceptions import FileNotSavedException, ViewNotRegisteredException, PathNotFoundException, \
+    FileNotFetchedException, DataFrameNotCreatedException, DataFrameNotAppendedException
 from flask import current_app
 from brainzutils.flask import CustomFlask
 from pyspark.sql.utils import AnalysisException
+
+def append(df, dest_path):
+    """ Append a dataframe to existing dataframe in HDFS or write a new one
+        if dataframe does not exist.
+
+        Args:
+            df (dataframe): Dataframe to append.
+            dest_path (string): Path where the existing dataframe is found or where a new dataframe should be created.
+    """
+    try:
+        df.write.mode('append').parquet(dest_path)
+    except Py4JJavaError as err:
+        raise DataFrameNotAppendedException(err.java_exception, df.schema)
 
 def create_app(debug=None):
     """ Uses brainzutils (https://github.com/metabrainz/brainzutils-python) to log exceptions to sentry.
@@ -38,6 +51,22 @@ def create_app(debug=None):
         sentry_config=app.config.get('LOG_SENTRY')
     )
     return app
+
+def create_dataframe(row, schema):
+    """ Create a dataframe containing a single row.
+
+        Args:
+            row (pyspark.sql.Row object): A Spark SQL row.
+            schema: Dataframe schema.
+
+        Returns:
+            df (dataframe): Newly created dataframe.
+    """
+    try:
+        df = listenbrainz_spark.session.createDataFrame([row], schema=schema)
+        return df
+    except Py4JJavaError as err:
+        raise DataFrameNotCreatedException(err.java_exception, row)
 
 def create_path(path):
     try:


### PR DESCRIPTION
This PR has been rebased on #52 

This PR fills the model_metadata data frame partially when create_dataframe is invoked. When train_model will be invoked, the script will update that row where *updated = False* and *dataframe_created* is maximum. 