### PR TITLE
Add checkpoint to break and save RDD lineage during iterative process

### DIFF
--- a/listenbrainz_spark/exceptions.py
+++ b/listenbrainz_spark/exceptions.py
@@ -5,6 +5,13 @@ class SparkException(Exception):
     def __str__(self):
         return self.message
 
+class HDFSException(Exception):
+    def __init__(self, message):
+        self.message = message
+
+    def __str__(self):
+        return self.message
+
 class FileNotFetchedException(SparkException):
     """ Failed to fetch a file from secondary storage.
     """
@@ -18,6 +25,13 @@ class FileNotSavedException(SparkException):
     def __init__(self, message, file_path):
         self.error_msg = 'File could not be saved to {}\n{}'.format(file_path, message)
         super(FileNotSavedException, self).__init__(self.error_msg)
+
+class HDFSDirectoryNotDeletedException(HDFSException):
+    """ Failed to delete an HDFS directory.
+    """
+    def __init__(self, message, file_path):
+        self.error_msg = 'Directory with the following path could not be deleted: {}\n{}'.format(file_path, message)
+        super(HDFSDirectoryNotDeletedException, self).__init__(self.error_msg)
 
 class PathNotFoundException(SparkException):
     """ Failed to find a given path in secondary storage.

--- a/listenbrainz_spark/recommendations/train_models.py
+++ b/listenbrainz_spark/recommendations/train_models.py
@@ -215,6 +215,7 @@ def main():
         utils.delete_dir(path.CHECKPOINT_DIR, recursive=True)
     except HDFSDirectoryNotDeletedException as err:
         current_app.logger.error(str(err), exc_info=True)
+        sys.exit(-1)
 
     if SAVE_TRAINING_HTML:
         save_training_html(time_, num_training, num_validation, num_test, model_metadata, best_model_metadata, ti,

--- a/listenbrainz_spark/utils.py
+++ b/listenbrainz_spark/utils.py
@@ -10,9 +10,11 @@ from listenbrainz_spark import stats
 from listenbrainz_spark import config
 from listenbrainz_spark.stats import run_query
 from listenbrainz_spark import hdfs_connection
+from listenbrainz_spark.exceptions import FileNotSavedException, ViewNotRegisteredException, PathNotFoundException, \
+    FileNotFetchedException, HDFSDirectoryNotDeletedException
 
-from listenbrainz_spark.exceptions import FileNotSavedException, ViewNotRegisteredException, PathNotFoundException, FileNotFetchedException
 from flask import current_app
+from hdfs.util import HdfsError
 from brainzutils.flask import CustomFlask
 from pyspark.sql.utils import AnalysisException
 
@@ -137,7 +139,10 @@ def delete_dir(path, recursive=False):
               >> Raises HdfsError if trying to delete a non-empty directory.
                  For non-empty directory set recursive to 'True'.
     """
-    hdfs_connection.client.delete(path, recursive=recursive)
+    try:
+        hdfs_connection.client.delete(path, recursive=recursive)
+    except HdfsError as err:
+        raise HDFSDirectoryNotDeletedException(str(err), path)
 
 def get_status(path):
     """ Checks the status of a directory in HDFS. The function throws HdfsError if the directory


### PR DESCRIPTION
During iterative calls (usually when iterations > 10 ) Spark forgets RDD lineage. It is recommended to add checkpoints to break the long lineage of an RDD, save the breakpoint as a new base so that when the RDD is computed again in the next iteration the distance between base and the result is shorter. 