### PR TITLE
Keep track of view names to use same dataframe in different modules.

### DIFF
--- a/listenbrainz_spark/sql/__init__.py
+++ b/listenbrainz_spark/sql/__init__.py
@@ -1,6 +1,6 @@
 from listenbrainz_spark.stats import run_query
 
-def get_user_id(user_name):
+def get_user_id(user_name, user_view):
     """ Get user id using user name.
 
         Args:
@@ -11,7 +11,7 @@ def get_user_id(user_name):
     """
     result = run_query("""
         SELECT user_id
-          FROM user
-         WHERE user_name = '%s'
-    """ % user_name)
+          FROM {}
+         WHERE user_name = '{}'
+    """.format(user_view, user_name))
     return result.first()['user_id']

--- a/listenbrainz_spark/sql/recommend_queries.py
+++ b/listenbrainz_spark/sql/recommend_queries.py
@@ -1,6 +1,6 @@
 from listenbrainz_spark.stats import run_query
 
-def get_top_artists_recordings(user_id):
+def get_top_artists_recordings(user_id, top_artist_candidate_view):
     """ Prepare dataframe of recordings which belong to top artists listened to
         by the user.
 
@@ -16,12 +16,12 @@ def get_top_artists_recordings(user_id):
     top_artists_recordings_df = run_query("""
         SELECT user_id
              , recording_id
-          FROM top_artist
-         WHERE user_id = %s
-    """ % user_id)
+          FROM {}
+         WHERE user_id = {}
+    """.format(top_artist_candidate_view, user_id))
     return top_artists_recordings_df
 
-def get_similar_artists_recordings(user_id):
+def get_similar_artists_recordings(user_id, similar_artist_candidate_view):
     """ Prepare dataframe of recordings which belong to artists similar to top artists
         listened to by the user.
 
@@ -37,12 +37,12 @@ def get_similar_artists_recordings(user_id):
     similar_artists_recordings_df = run_query("""
         SELECT user_id
              , recording_id
-          FROM similar_artist
-         WHERE user_id = %s
-    """ % user_id)
+          FROM {}
+         WHERE user_id = {}
+    """.format(similar_artist_candidate_view, user_id))
     return similar_artists_recordings_df
 
-def get_recordings(recording_ids):
+def get_recordings(recording_ids, recording_view):
     """ Prepare dataframe of recommended recordings.
 
         Args:
@@ -62,7 +62,7 @@ def get_recordings(recording_ids):
              , artist_msid
              , release_name
              , release_msid
-          FROM recording
-         WHERE recording_id IN %s
-    """ % (recording_ids,))
+          FROM {}
+         WHERE recording_id IN {}
+    """.format(recording_view, recording_ids,))
     return df

--- a/listenbrainz_spark/view.py
+++ b/listenbrainz_spark/view.py
@@ -1,0 +1,55 @@
+# This file aims to keep track of view names which are used in different modules
+# and have been created from the same dataframe. Through this file we intend to avoid
+# naming same view with different names. View names of dataframe stored in HDFS and used at
+# multiple locations have been saved in here, if view names of intermediate dataframes are added
+# at some point, please add a comment to indicate to which module or dataframe it belongs and a line
+# to describe the usage of that view.
+# Don't forget to append the date to recognize view creation day.
+# Note: View here means a registered dataframe.
+# Note: View name containing hyphen throw exception in Spark, use backticks(`) to escape view names with hyphen.
+# NOte: We try to keep view names such so that it explains the type of data it contains.
+
+from datetime import datetime
+
+from listenbrainz_spark import config
+
+date = datetime.strftime(datetime.utcnow(),'%Y-%m-%d')
+# View created by registering dataframe containing listens which will be later used for training,
+# validation and testing (after preprocessing).
+LISTENS_TRAIN = '`train-listens-of-{}-days-{}`'.format(config.TRAIN_MODEL_WINDOW, date)
+# View created by registering dataframe containing track information specific to a user.
+LISTEN = '`listen-{}`'.format(date)
+# View created by registering dataframe containing distinct user names.
+USER = '`user-{}`'.format(date)
+# View created by registering dataframe containing distinct recording msids.
+RECORDING = '`recording-{}`'.format(date)
+
+# Refer sql.create_dataframe_queries to know how the above mentioned views are created.
+# These views have been created by querying LISTENS_TRAIN view.
+
+# Since listens are stored month wise, we regitser a dataframe containing listens of months(s) of which listens of
+# days on which we wish to generate recommendations is a subset.
+LISTENS_MONTHS = '`user-listens-months(s)-{}`'.format(date)
+# View created by registering dataframe containing listens of days on which we wish to generate the recommendations.
+# This view is created by querying LISTENS_MONTHS.
+LISTENS_DAYS = '`user-listens-{}-days-{}`'.format(config.RECOMMENDATION_GENERATION_WINDOW, date)
+# View created by registering dataframe containing artist-artist relation i.e. similar artists.
+ARTIST_RELATION = '`artist-relation-{}`'.format(date)
+
+# View created by registering dataframe containing top artists listened to by a user.
+TOP_ARTIST = '`top-artist-{}'.format(date)
+# View created by registering dataframe containing artists similar to top artists listened to by a user.
+SIMILAR_ARTIST = '`similar-artist-{}'.format(date)
+
+# Note: The above mentioned views are specific to a user.
+# Therefore, user name must be appended to these views before registering the dataframes.
+# Closing backtick should be appended after the user name.
+# Refer sql.candidate_set_queries to know how the above mentioned views are created.
+
+# View created by registering dataframe containing user ids and recording ids of top artists listened to by a user for all users.
+TOP_ARTIST_CANDIDATE = '`top-artist-candidate-{}`'.format(date)
+# View created by registering dataframe containing user ids and recording ids of artists similar to top artists
+# listened to by a user for all users.
+SIMILAR_ARTIST_CANDIDATE = '`similar-artist-candidate-{}`'.format(date)
+
+# Refer to sql.recommend_queries to know how the above mentioned views are created.


### PR DESCRIPTION
right now, view names are hard-coded which makes it difficult to debug and handle code. View.py properly formats view names and makes it easy to register the same dataframe between different modules.