### PR TITLE
Fix test.sh by removing the datanode volume

### DIFF
--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -1,7 +1,6 @@
 version: "3.4"
 
 volumes:
-    datanode:
     namenode:
 
 services:
@@ -14,8 +13,6 @@ services:
   datanode:
     image: metabrainz/hadoop-yarn:beta
     command: hdfs datanode
-    volumes:
-      - datanode:/home/hadoop/hdfs:z
 
   test:
     build:

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -1,9 +1,17 @@
 version: "3.4"
 
+volumes:
+  namenode:
+
 services:
   hadoop-master:
     image: metabrainz/hadoop-yarn:beta
     command: hdfs namenode
+    ports:
+      - "9000:9000"
+      - "9870:9870"
+    volumes:
+      - namenode:/home/hadoop/hdfs:z
 
   datanode:
     image: metabrainz/hadoop-yarn:beta
@@ -14,6 +22,6 @@ services:
       context: ..
       dockerfile: Dockerfile
       target: metabrainz-spark-dev
-    command: py.test --junitxml=/data/test_report.xml --cov-report xml:/data/coverage.xml
+    command: dockerize -wait tcp://hadoop-master:9000 -timeout 60s bash -c "py.test --junitxml=/data/test_report.xml --cov-report xml:/data/coverage.xml"
     volumes:
       - ..:/rec:z

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -1,14 +1,9 @@
 version: "3.4"
 
-volumes:
-    namenode:
-
 services:
   hadoop-master:
     image: metabrainz/hadoop-yarn:beta
     command: hdfs namenode
-    volumes:
-      - namenode:/home/hadoop/hdfs:z
 
   datanode:
     image: metabrainz/hadoop-yarn:beta

--- a/test.sh
+++ b/test.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 
-# NOTE:
-# If the hadoop-master container seems to keep dying because "Namenode is not formatted" or similar
-# format it using the following command
-# `docker-compose -f docker/docker-compose.test.yml -p listenbrainz_labs_test run --rm hadoop-master hdfs namenode -format`
-
+docker-compose -f docker/docker-compose.test.yml -p listenbrainz_labs_test run --rm hadoop-master hdfs namenode -format
 docker-compose -f docker/docker-compose.test.yml -p listenbrainz_labs_test up -d hadoop-master datanode
 docker-compose -f docker/docker-compose.test.yml -p listenbrainz_labs_test up test
 docker-compose -f docker/docker-compose.test.yml -p listenbrainz_labs_test down

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-docker-compose -f docker/docker-compose.test.yml -p listenbrainz_labs_test run --rm hadoop-master hdfs namenode -format
+docker-compose -f docker/docker-compose.test.yml -p listenbrainz_labs_test run --rm hadoop-master hdfs namenode -format -nonInteractive -force
 docker-compose -f docker/docker-compose.test.yml -p listenbrainz_labs_test up -d hadoop-master datanode
 docker-compose -f docker/docker-compose.test.yml -p listenbrainz_labs_test up test
 docker-compose -f docker/docker-compose.test.yml -p listenbrainz_labs_test down


### PR DESCRIPTION
This allows us to format namenodes and datanodes will always
be ok.

cc @vansika, please test this. I've tested it on leader and test.sh works for me.