### PR TITLE
Add tests for request consumer and fix test.sh path problems

### DIFF
--- a/docker/docker-compose.jenkins.yml
+++ b/docker/docker-compose.jenkins.yml
@@ -25,4 +25,4 @@ services:
       context: ..
       dockerfile: Dockerfile
       target: metabrainz-spark-dev
-    command: dockerize -wait tcp://hadoop-master:9000 -timeout 60s bash -c "cp listenbrainz_spark/config.py.sample listenbrainz_spark/config.py; py.test --junitxml=/data/test_report.xml --cov-report xml:/data/coverage.xml"
+    command: dockerize -wait tcp://hadoop-master:9000 -timeout 60s bash -c "cp listenbrainz_spark/config.py.sample listenbrainz_spark/config.py; python -m pytest --junitxml=/data/test_report.xml --cov-report xml:/data/coverage.xml"

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -22,6 +22,6 @@ services:
       context: ..
       dockerfile: Dockerfile
       target: metabrainz-spark-dev
-    command: dockerize -wait tcp://hadoop-master:9000 -timeout 60s bash -c "py.test --junitxml=/data/test_report.xml --cov-report xml:/data/coverage.xml"
+    command: dockerize -wait tcp://hadoop-master:9000 -timeout 60s bash -c "python -m pytest --junitxml=/data/test_report.xml --cov-report xml:/data/coverage.xml"
     volumes:
       - ..:/rec:z

--- a/listenbrainz_spark/query_map.py
+++ b/listenbrainz_spark/query_map.py
@@ -3,3 +3,7 @@ import listenbrainz_spark.stats.user.all
 functions = {
 	'stats.user.all': listenbrainz_spark.stats.user.all.calculate,
 }
+
+
+def get_query_handler(query):
+    return functions[query]

--- a/listenbrainz_spark/request_consumer/request_consumer.py
+++ b/listenbrainz_spark/request_consumer/request_consumer.py
@@ -40,7 +40,7 @@ class RequestConsumer:
             return None
 
         try:
-            query_handler = listenbrainz_spark.query_map.functions[query]
+            query_handler = listenbrainz_spark.query_map.get_query_handler(query)
         except KeyError:
             current_app.logger.error("Bad query sent to spark request consumer: %s", query, exc_info=True)
             return None

--- a/listenbrainz_spark/request_consumer/test_request_consumer.py
+++ b/listenbrainz_spark/request_consumer/test_request_consumer.py
@@ -6,7 +6,7 @@ from listenbrainz_spark.request_consumer.request_consumer import RequestConsumer
 
 class RequestConsumerTestCase(SparkTestCase):
 
-    def setUp():
+    def setUp(self):
         self.consumer = RequestConsumer()
         self.consumer.rabbitmq = MagicMock()
         self.consumer.request_channel = MagicMock()

--- a/listenbrainz_spark/request_consumer/test_request_consumer.py
+++ b/listenbrainz_spark/request_consumer/test_request_consumer.py
@@ -1,0 +1,21 @@
+from unittest.mock import patch, MagicMock
+
+from listenbrainz_spark.tests import SparkTestCase
+from listenbrainz_spark.request_consumer.request_consumer import RequestConsumer
+
+
+class RequestConsumerTestCase(SparkTestCase):
+
+    def setUp():
+        self.consumer = RequestConsumer()
+        self.consumer.rabbitmq = MagicMock()
+        self.consumer.request_channel = MagicMock()
+        self.consumer.result_channel = MagicMock()
+
+    @patch('listenbrainz_spark.request_consumer.request_consumer.init_rabbitmq')
+    def test_connect_to_rabbitmq(self, mock_init_rabbitmq):
+        with create_app().app_context():
+            self.consumer.connect_to_rabbitmq()
+            mock_init_rabbitmq.assert_called_once()
+
+

--- a/listenbrainz_spark/request_consumer/test_request_consumer.py
+++ b/listenbrainz_spark/request_consumer/test_request_consumer.py
@@ -13,10 +13,32 @@ class RequestConsumerTestCase(SparkTestCase):
         self.consumer.request_channel = MagicMock()
         self.consumer.result_channel = MagicMock()
 
+    @patch('listenbrainz_spark.request_consumer.request_consumer.current_app')
     @patch('listenbrainz_spark.request_consumer.request_consumer.init_rabbitmq')
-    def test_connect_to_rabbitmq(self, mock_init_rabbitmq):
-        with create_app().app_context():
+    def test_connect_to_rabbitmq(self, mock_init_rabbitmq, mock_current_app):
             self.consumer.connect_to_rabbitmq()
             mock_init_rabbitmq.assert_called_once()
 
+    @patch('listenbrainz_spark.request_consumer.request_consumer.current_app')
+    def test_get_result_if_bad_query(self, mock_current_app):
+        # should return none if no query
+        self.assertIsNone(self.consumer.get_result({}))
 
+        # should return none if unrecognized query
+        self.assertIsNone(self.consumer.get_result({'query': 'idk_what_this_means'}))
+
+    @patch('listenbrainz_spark.request_consumer.request_consumer.current_app')
+    @patch('listenbrainz_spark.query_map.get_query_handler')
+    def test_get_result_if_query_recognized(self, mock_get_query_handler, mock_current_app):
+        # should call the returned function if query is recognized
+        # create the mock query handler
+        mock_query_handler = MagicMock()
+        mock_query_handler.return_value = {'result': 'ok'}
+
+        # make the get_query_handler function return the mock query handler
+        mock_get_query_handler.return_value = mock_query_handler
+
+        # assert that we get the correct result
+        self.assertEqual(self.consumer.get_result({'query': 'i_know_what_this_means'}), {'result': 'ok'})
+        mock_get_query_handler.assert_called_once()
+        mock_query_handler.assert_called_once()

--- a/listenbrainz_spark/request_consumer/test_request_consumer.py
+++ b/listenbrainz_spark/request_consumer/test_request_consumer.py
@@ -1,7 +1,8 @@
 from unittest.mock import patch, MagicMock
 
-from listenbrainz_spark.tests import SparkTestCase
 from listenbrainz_spark.request_consumer.request_consumer import RequestConsumer
+from listenbrainz_spark.tests import SparkTestCase
+from listenbrainz_spark.utils import create_app
 
 
 class RequestConsumerTestCase(SparkTestCase):

--- a/listenbrainz_spark/tests/test_utils.py
+++ b/listenbrainz_spark/tests/test_utils.py
@@ -1,8 +1,6 @@
 import os
-import unittest
 from datetime import datetime
 
-import listenbrainz_spark
 from listenbrainz_spark.tests import SparkTestCase
 from listenbrainz_spark import utils, hdfs_connection, config
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz Labs. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Description

<!--
 A one line description of what this change does
-->
Adding tests for request consumer as that is something close to prod.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.
-->

* Need to add tests to request_consumer to be confident that we're not breaking it while making changes to it.
* There was a problem with test.sh imports where py.test didn't add the code dir to PYTHONPATH meaning that we couldn't import `SparkTestCase` anywhere outside `listenbrainz_spark.tests`. 


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section. How did you test the change?
-->
* Add tests
* Instead of using `py.test`, call tests via `python -m pytest` (https://stackoverflow.com/a/34140498)

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

NA, just review and merge.
