### PR TITLE
Move import script to manage.py

### DIFF
--- a/import.py
+++ b/import.py
@@ -1,9 +1,0 @@
-import sys
-from listenbrainz_spark.data import import_dump 
-
-if __name__ == '__main__':
-    if len(sys.argv) != 3:
-        print("Usage: import.py <app_name> <dump_file>")
-        sys.exit(-1)
-
-    import_dump.main(app_name=sys.argv[1], archive=sys.argv[2])

--- a/manage.py
+++ b/manage.py
@@ -124,7 +124,7 @@ def request_consumer():
         main('request-consumer-%s' % str(int(time.time())))
 
 @cli.command(name="import")
-@click.argument('filename')
+@click.argument('filename', type=click.Path(exists=True))
 def import(filename):
     import_dump.main(app_name='import', archive=filename)
 

--- a/manage.py
+++ b/manage.py
@@ -9,6 +9,7 @@ from listenbrainz_spark import path
 from listenbrainz_spark import utils
 from listenbrainz_spark import config
 from listenbrainz_spark import hdfs_connection
+from listenbrainz_spark.data import import_dump
 
 from hdfs.util import HdfsError
 from py4j.protocol import Py4JJavaError
@@ -121,6 +122,11 @@ def request_consumer():
     from listenbrainz_spark.request_consumer.request_consumer import main
     with app.app_context():
         main('request-consumer-%s' % str(int(time.time())))
+
+@cli.command(name="import")
+@click.argument('filename')
+def import(filename):
+    import_dump.main(app_name='import', archive=filename)
 
 
 @cli.resultcallback()

--- a/manage.py
+++ b/manage.py
@@ -125,7 +125,7 @@ def request_consumer():
 
 @cli.command(name="import")
 @click.argument('filename', type=click.Path(exists=True))
-def import_dump(filename):
+def import_dump_command(filename):
     import_dump.main(app_name='import', archive=filename)
 
 

--- a/manage.py
+++ b/manage.py
@@ -125,7 +125,7 @@ def request_consumer():
 
 @cli.command(name="import")
 @click.argument('filename', type=click.Path(exists=True))
-def import(filename):
+def import_dump(filename):
     import_dump.main(app_name='import', archive=filename)
 
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to ListenBrainz Labs. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    ./github/CONTRIBUTING.md.
-->

# Description

<!--
 A one line description of what this change does
-->
Move the import listens script to manage.py for consistency

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address? Please try to
    think of people who do not have the context you have on the problem.
-->

* JIRA ticket (_optional_): <!-- [LB-XXX](https://tickets.metabrainz.org/browse/LB-XXX) -->

There was a different import script `import.py`. When importing the listens into the new setup, this confused me.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section. How did you test the change?
-->

Remove the import.py script and add an import command to manage.py


