### PR TITLE
disable creation of pycache files with pytest

### DIFF
--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -22,6 +22,6 @@ services:
       context: ..
       dockerfile: Dockerfile
       target: metabrainz-spark-dev
-    command: dockerize -wait tcp://hadoop-master:9000 -timeout 60s bash -c "python -m pytest --junitxml=/data/test_report.xml --cov-report xml:/data/coverage.xml"
+    command: dockerize -wait tcp://hadoop-master:9000 -timeout 60s bash -c "PYTHONDONTWRITEBYTECODE=1 python -m pytest --junitxml=/data/test_report.xml --cov-report xml:/data/coverage.xml"
     volumes:
       - ..:/rec:z


### PR DESCRIPTION
# Description
This PR disables creation of __pycache__ files with test.sh

# Problem
__pycache__ files produced with tests lead to the following error when running spark-submit 
`zip warning: Permission denied
	zip warning: could not open for reading: listenbrainz_spark/request_consumer/__pycache__/test_request_consumer.cpython-36-pytest-5.2.2.pyc`

# Solution
https://github.com/pytest-dev/pytest/issues/200

# Action
set `PYTHONDONTWRITEBYTECODE=1` in docker-compose.test.yml

